### PR TITLE
Remove $ sign

### DIFF
--- a/extras/tg_scrape.jl
+++ b/extras/tg_scrape.jl
@@ -74,15 +74,17 @@ function process_table(x, methods, io)
         print(cio, "\n")
     end
 
+    takeclean(input) = replace(strip(String(take!(input))), '$' => "D")
+    
     if isrequired
         print(io, "# Required arguments\n")
-        print(io, strip(String(take!(required))))
+        print(io, takeclean(required))
         print(io, "\n\n")
     end
 
     if isoptional
         print(io, "# Optional arguments\n")
-        print(io, strip(String(take!(optional))))
+        print(io, takeclean(optional))
         print(io, "\n")
     end
 


### PR DESCRIPTION
In the description of Telegram API dollar sign appears two times, thus the precompilation stucks because '$' is passed without escape sign in generated telegram_api.jl file. Here $ is replaced with D, as a result, getting "USD" instead of "US$".